### PR TITLE
Add android platform

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,3 +26,5 @@ urigo:angular-blaze-template
 less
 accounts-facebook
 service-configuration
+materialize:materialize@=0.97.0
+mbenford:ng-tags-input

--- a/.meteor/platforms
+++ b/.meteor/platforms
@@ -1,2 +1,3 @@
-server
+android
 browser
+server

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -6,6 +6,7 @@ accounts-ui@1.1.6
 accounts-ui-unstyled@1.1.8
 angular@1.0.0-rc.11
 angular:angular@1.4.6
+angularjs:angular@1.3.15
 angularui:angular-ui-router@0.2.15
 autopublish@1.0.4
 autoupdate@1.2.3
@@ -50,6 +51,8 @@ less@2.5.0_3
 livedata@1.0.15
 localstorage@1.0.5
 logging@1.0.8
+materialize:materialize@0.97.0
+mbenford:ng-tags-input@2.3.0
 meteor@1.1.9
 meteor-base@1.0.1
 minifiers@1.1.7

--- a/client/bootstrap.js
+++ b/client/bootstrap.js
@@ -1,0 +1,13 @@
+// Boot the app
+(function() {
+  var onReady = function() {
+    angular.bootstrap(document, ['emmersive']);
+  };
+
+  if (Meteor.isCordova) {
+    angular.element(document).on("deviceready", onReady);
+  }
+  else {
+    angular.element(document).ready(onReady);
+  }
+})();

--- a/client/controllers/projects.js
+++ b/client/controllers/projects.js
@@ -15,4 +15,4 @@ angular.module('emmersive')
       $location.path('/projects');
     };
 
-}])
+}]);

--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
 </head>
 
 <body>
-  <nav class="black" role="navigation">
+  <nav class="black fixed" role="navigation">
     <div class="nav-wrapper container">
       <a id="logo-container" href="/" class="brand-logo"><img src="/emmersive.png" class="responsive-img"></a>
 

--- a/client/index.html
+++ b/client/index.html
@@ -1,68 +1,44 @@
 <head>
   <title>emmersive</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
-
-  <!--Import Google Icon Font-->
-  <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">  
-    
-  <!-- Compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/css/materialize.min.css">
-  <!-- Compiled and minified JavaScript -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/js/materialize.min.js"></script>
-
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ng-tags-input/3.0.0/ng-tags-input.bootstrap.min.css">
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ng-tags-input/3.0.0/ng-tags-input.min.js"></script>
-
-  <script type="text/javascript">
-    setTimeout(function(){
-      $('.button-collapse').sideNav();
-    }, 200);
-  </script>
-
-  <!--Let browser know website is optimized for mobile-->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <base href="/">
 </head>
 
 <body>
-  <div ng-app="emmersive">
+  <nav class="black" role="navigation">
+    <div class="nav-wrapper container">
+      <a id="logo-container" href="/" class="brand-logo"><img src="/emmersive.png" class="responsive-img"></a>
 
-    <nav class="black" role="navigation">
-      <div class="nav-wrapper container">
-        <a id="logo-container" href="/" class="brand-logo"><img src="/emmersive.png" class="responsive-img"></a>
+        <ul class="right hide-on-med-and-down">
+          <li><a href="/projects">Discover</a></li>
+          <li ng-if="currentUser"><a href="/projects/new">Start a Project</a></li>
+          <li ng-if="currentUser"><a href="/me">My Profile</a></li>
+          <li><blaze-template name="loginButtons"></blaze-template></li>
+        </ul>
 
-          <ul class="right hide-on-med-and-down">
-            <li><a href="/projects">Discover</a></li>
-            <li ng-if="currentUser"><a href="/projects/new">Start a Project</a></li>
-            <li ng-if="currentUser"><a href="/me">My Profile</a></li>
-            <li><blaze-template name="loginButtons"></blaze-template></li>
-          </ul>
+        <ul id="nav-mobile" class="side-nav">
+          <li><a href="/">Home</a></li>
+          <li><a href="/projects">Discover</a></li>
+          <li ng-if="currentUser"><a href="/projects/new">Start a Project</a></li>
+          <li ng-if="currentUser"><a href="/me">My Profile</a></li>
+          <li><blaze-template name="loginButtons"></blaze-template></li>
+        </ul>
 
-          <ul id="nav-mobile" class="side-nav">
-            <li><a href="/projects">Discover</a></li>
-            <li><a href="/projects/new">Start a Project</a></li>
-            <li ng-if="currentUser"><a href="/me">My Profile</a></li>
-            <li><blaze-template name="loginButtons"></blaze-template></li>
-          </ul>
+      <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="mdi-navigation-menu"></i></a>
+    </div>
+  </nav>
 
-        <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
-      </div>
-    </nav>
+  <div ng-class="($location.path() === '/') ? 'fullPage' : 'container'">
+    <div class="section">
+      <div ui-view></div>
+    </div>
+  </div>
 
-    <div ng-class="($location.path() === '/') ? 'fullPage' : 'container'"> 
-      <div class="section">
-        <div ui-view></div>
+  <footer class="page-footer grey darken-1">
+    <div class="footer-copyright">
+      <div class="container">
+        Made with <span class="orange-text text-lighten-3">Whiskey</span>
       </div>
     </div>
-
-    <footer class="page-footer grey darken-1">
-      <div class="footer-copyright">
-        <div class="container">
-          Made with <span class="orange-text text-lighten-3">Whiskey</span>
-        </div>
-      </div>
-    </footer>
-
-  </div> 
+  </footer>
 </body>

--- a/client/lib/app.js
+++ b/client/lib/app.js
@@ -1,5 +1,7 @@
 angular.module('emmersive',['angular-meteor', 'ui.router', 'ngTagsInput'])
 .run(['$rootScope', '$location', function($rootScope, $location){
-    $rootScope.$location = $location;
-}])
-
+  $rootScope.$location = $location;
+  $('.button-collapse').sideNav({
+    closeOnClick: true
+  });
+}]);

--- a/client/styles/main.less
+++ b/client/styles/main.less
@@ -54,3 +54,18 @@ tags-input .tags .tag-item {
     border-radius: 50%;
   }
 }
+
+nav {
+  &.fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    z-index: 1000;
+  }
+}
+
+body {
+  padding-top: 60px;
+}

--- a/client/styles/main.less
+++ b/client/styles/main.less
@@ -1,14 +1,14 @@
 body {
   background-color: rgba(0,0,0,.2);
 }
-.tag-list li { 
-  display: inline-block; 
+.tag-list li {
+  display: inline-block;
   margin-right:10px;
   padding: 5px;
 }
 
 tags-input {
-  
+
   textarea, input { outline: none!important; }
 
   :focus {
@@ -25,11 +25,32 @@ tags-input {
   a {
     color: #000!important;
   }
-} 
+}
 
 tags-input .tags .tag-item {
   background: #E4E4E4!important;
   color: rgba(0,0,0,0.6)!important;
   border-radius: 4px;
   border:none!important;
+}
+
+.chip {
+  display: inline-block;
+  height: 32px;
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+  line-height: 32px;
+  padding: 0 12px;
+  border-radius: 16px;
+  background-color: #E4E4E4;
+  margin: 2px;
+
+  img {
+    float: left;
+    margin: 0 8px 0 -12px;
+    height: 32px;
+    width: 32px;
+    border-radius: 50%;
+  }
 }

--- a/client/views/home.ng.html
+++ b/client/views/home.ng.html
@@ -1,3 +1,3 @@
 
-<h1 style="width:100%;text-align:center;color:white;font-size:150px;position:absolute;text-shadow: 2px 2px #000;">OBEY</h1>
-<img style="display: block; margin:auto;" src="school1.jpg">
+<h1 style="width:100%;text-align:center;color:white;font-size:140px;position:absolute;text-shadow: 2px 2px #000;">OBEY</h1>
+<div style="display: block; margin:auto; background-image: url('school1.jpg'); background-position-x: center; background-repeat: no-repeat; height: 600px"></div>

--- a/client/views/home.ng.html
+++ b/client/views/home.ng.html
@@ -1,5 +1,3 @@
 
 <h1 style="width:100%;text-align:center;color:white;font-size:150px;position:absolute;text-shadow: 2px 2px #000;">OBEY</h1>
-<img src="school1.jpg">
-
-
+<img style="display: block; margin:auto;" src="school1.jpg">

--- a/client/views/project.ng.html
+++ b/client/views/project.ng.html
@@ -3,28 +3,26 @@
 
     <div class="row">
       <div class="col s12 m8">
-         <h1>{{project.name}}</h1>                     
+         <h1>{{project.name}}</h1>
       </div>
       <div class="col s12 m4 right-align">
         <button ng-click="editing=true" class="btn-floating btn-large red">
-          <i class="large mdi-editor-mode-edit"></i>
+          <i class="mdi-editor-mode-edit"></i>
         </button>
 
         <button ng-click="remove()" class="btn-floating btn-large grey">
-          <i class="material-icons dp8">delete</i><span>delete</span>
-        </button>         
+          <i class="mdi-action-delete"></i>
+        </button>
       </div>
     </div>
 
-    {{project.description}}
+    <p>{{project.description}}</p>
 
     <div class="section">
       <h6>Skills Needed</h6>
-      <span ng-repeat="skill in project.skills_needed">
-        <div class="chip" >
-          {{skill.text}}
-        </div> 
-      </span>
+      <div class="chip" ng-repeat="skill in project.skills_needed | orderBy: 'text'">
+        {{skill.text}}
+      </div>
     </div>
 
   </div>
@@ -61,6 +59,3 @@
     </div>
   </div>
 </div>
-
-
-


### PR DESCRIPTION
This adds cordova support and an android target. All the resources have to be bundled for cordova to work (no cdn) so I moved it to the meteor packages. I had to patch in `.chip` because the latest meteor package for materializecss is broken. Also the version that worked didn't support the ligature icon format, so I converted the icons to the css types.

Navigation is still a little screwy for a mobile device. Probably should just get some sliding tabs or something.

To see the android app, you run with `meteor run android` and it will boot an emulator. You may have to play with android studio and get an sdk, but I think it has a script to install an sdk, as well. The android SDK comes with an emulator.

Had to fork to open a PR, because I don't have access to the main repo. :(
